### PR TITLE
ノート添付された画像をTwitterにもアップロードして添付する機能

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,7 @@
     "./"
   ],
   "deno.enable": true,
-  "editor.inlayHints.enabled": "off"
+  "editor.inlayHints.enabled": "off",
+  "deno.lint": true,
+  "deno.unstable": true
 }

--- a/index.ts
+++ b/index.ts
@@ -40,7 +40,8 @@ app.post("/", async (c) => {
     return c.text(msg, 403);
   }
   const uploadableFiles = (files ?? []).filter((f) =>
-    f.type.includes("image") || f.type === "video/mp4"
+    f.type === "image/jpeg" || f.type === "image/png" ||
+    f.type === "image/webp" || f.type === "image/gif" || f.type === "video/mp4"
   );
   const [uploadFiles, unuploadFiles] = [
     uploadableFiles.slice(0, 4),

--- a/index.ts
+++ b/index.ts
@@ -1,59 +1,80 @@
-import { Hono } from 'https://deno.land/x/hono@v3.4.1/mod.ts'
-import { load } from 'https://deno.land/std@0.198.0/dotenv/mod.ts'
-import { Payload } from './types.ts'
-import { tweet } from './twitter.ts'
+import { Hono } from "https://deno.land/x/hono@v3.4.1/mod.ts";
+import { load } from "https://deno.land/std@0.198.0/dotenv/mod.ts";
+import { Payload } from "./types.ts";
+import { tweet, uploadMediaFromURL } from "./twitter.ts";
 
 const timelog = (text: string, content?: string) => {
-    console.log(`${new Date().toLocaleString('ja-JP', { timeZone: 'JST' })
-        }: ${text}\n${content?.replace(/^/gm, '> ') ?? ''}`)
-}
+  console.log(
+    `${new Date().toLocaleString("ja-JP", { timeZone: "JST" })}: ${text}\n${
+      content?.replace(/^/gm, "> ") ?? ""
+    }`,
+  );
+};
 
-const env = await load()
+const env = await load();
 const [secret, authToken, ct0] = [
-    'MISSKEY_WEBHOOK_SECRET',
-    'TWITTER_AUTH_TOKEN',
-    'TWITTER_CT0'
-].map(key => Deno.env.get(key) ?? env[key] ?? '')
+  "MISSKEY_WEBHOOK_SECRET",
+  "TWITTER_AUTH_TOKEN",
+  "TWITTER_CT0",
+].map((key) => Deno.env.get(key) ?? env[key] ?? "");
 
-const app = new Hono()
+const app = new Hono();
 
-app.post('/', async c => {
-    const requestSecret: string = c.req.header('X-Misskey-Hook-Secret') ?? ''
-    if (requestSecret !== secret) {
-        const msg = 'wrong secret'
-        timelog(msg)
-        return c.text(msg, 403)
-    }
-    const payload: Payload = await c.req.json()
-    const { text, cw, visibility, localOnly, files } = payload.body.note
-    if (localOnly) {
-        const msg = `post visibility: "local only"`
-        timelog(msg)
-        return c.text(msg, 403)
-    }
-    if (visibility !== 'public' && visibility !== 'home') {
-        const msg = `post visibility: "${visibility}"`
-        timelog(msg)
-        return c.text(msg, 403)
-    }
-    const filesStr: string = (files ?? []).reduce((p: string, c) => {
-        return `${p}\n${c.type.includes('image') ? '🖼' : '📄'} ${c.url}`
-    }, '')
-    const tweetContent = (cw ? `${cw}...\n\n` : '') + (text ?? '') + filesStr
-    if (!tweetContent) {
-        const msg = 'empty content'
-        timelog(msg)
-        return c.text(msg, 403)
-    }
-    const res = await tweet(tweetContent, authToken, ct0)
-    if (res.status === 200) {
-        const msg = 'successfully tweeted'
-        timelog(msg, tweetContent)
-        return c.text(msg, 200)
-    }
-    const msg = 'error while tweeting'
-    timelog(msg, tweetContent)
-    return c.text(msg, 403)
-})
+app.post("/", async (c) => {
+  const requestSecret: string = c.req.header("X-Misskey-Hook-Secret") ?? "";
+  if (requestSecret !== secret) {
+    const msg = "wrong secret";
+    timelog(msg);
+    return c.text(msg, 403);
+  }
+  const payload: Payload = await c.req.json();
+  const { text, cw, visibility, localOnly, files } = payload.body.note;
+  if (localOnly) {
+    const msg = `post visibility: "local only"`;
+    timelog(msg);
+    return c.text(msg, 403);
+  }
+  if (visibility !== "public" && visibility !== "home") {
+    const msg = `post visibility: "${visibility}"`;
+    timelog(msg);
+    return c.text(msg, 403);
+  }
+  const uploadableFiles = (files ?? []).filter((f) =>
+    f.type.includes("image") || f.type === "video/mp4"
+  );
+  const [uploadFiles, unuploadFiles] = [
+    uploadableFiles.slice(0, 4),
+    uploadableFiles.slice(4),
+  ];
+  const mediaIds = await Promise.all(
+    uploadFiles.map(async (file) =>
+      await uploadMediaFromURL(file.url, file.type, authToken, ct0)
+    ),
+  );
 
-Deno.serve(app.fetch)
+  const filesStr: string = [
+    ...unuploadFiles,
+    ...(files ?? []).filter((f) =>
+      !(f.type.includes("image") || f.type === "video/mp4")
+    ),
+  ].reduce((p: string, c) => {
+    return `${p}\n${c.type.includes("image") ? "🖼" : "📄"} ${c.url}`;
+  }, "");
+  const tweetContent = (cw ? `${cw}...\n\n` : "") + (text ?? "") + filesStr;
+  if (!tweetContent) {
+    const msg = "empty content";
+    timelog(msg);
+    return c.text(msg, 403);
+  }
+  const res = await tweet(tweetContent, authToken, ct0, mediaIds);
+  if (res.status === 200) {
+    const msg = "successfully tweeted";
+    timelog(msg, tweetContent);
+    return c.text(msg, 200);
+  }
+  const msg = "error while tweeting";
+  timelog(msg, tweetContent);
+  return c.text(msg, 403);
+});
+
+Deno.serve(app.fetch);

--- a/index.ts
+++ b/index.ts
@@ -39,14 +39,28 @@ app.post("/", async (c) => {
     timelog(msg);
     return c.text(msg, 403);
   }
-  const uploadableFiles = (files ?? []).filter((f) =>
+  const uploadableImages = (files ?? []).filter((f) =>
     f.type === "image/jpeg" || f.type === "image/png" ||
-    f.type === "image/webp" || f.type === "image/gif" || f.type === "video/mp4"
+    f.type === "image/webp"
   );
-  const [uploadFiles, unuploadFiles] = [
-    uploadableFiles.slice(0, 4),
-    uploadableFiles.slice(4),
-  ];
+  const uploadableVideos = (files ?? []).filter((f) =>
+    f.type === "image/gif" || f.type === "video/mp4"
+  );
+  const [uploadFiles, unuploadFiles] = uploadableVideos.length > 0
+    ? [
+      uploadableImages.slice(0, 1),
+      [
+        ...uploadableImages,
+        ...uploadableVideos.slice(1),
+      ],
+    ]
+    : [
+      uploadableImages.slice(0, 4),
+      [
+        ...uploadableImages.slice(4),
+        ...uploadableVideos,
+      ],
+    ];
   const mediaIds = await Promise.all(
     uploadFiles.map(async (file) =>
       await uploadMediaFromURL(file.url, file.type, authToken, ct0)

--- a/twitter.ts
+++ b/twitter.ts
@@ -75,13 +75,14 @@ export const uploadMediaFromURL = async (
   const mediaType = match(type, {
     "image/jpeg": () => "tweet_image",
     "image/png": () => "tweet_image",
+    "image/webp": () => "tweet_image",
     "image/gif": () => "tweet_gif",
     "video/mp4": () => "tweet_video",
 
     [match._]: () => {
       throw new Error(`Unsupported media type: ${type}`);
-    }
-  })
+    },
+  });
 
   const initURL =
     `https://upload.twitter.com/i/media/upload.json?command=INIT&total_bytes=${blob.size}&media_type=${
@@ -99,7 +100,6 @@ export const uploadMediaFromURL = async (
     },
   });
   if (!uploadInitRes.ok) {
-    console.log(uploadInitRes);
     throw new Error("Failed to initialize upload");
   }
   const mediaInfo: { media_id_string: string } = await uploadInitRes.json();
@@ -127,7 +127,6 @@ export const uploadMediaFromURL = async (
       },
     });
     if (!uploadAppendRes.ok) {
-      console.log(uploadAppendRes);
       throw new Error(`Failed to upload chunk ${index}`);
     }
   }));

--- a/twitter.ts
+++ b/twitter.ts
@@ -1,39 +1,152 @@
-export const tweet = async (text: string, authToken: string, ct0: string) => {
-    const url = 'https://twitter.com/i/api/graphql/tTsjMKyhajZvK4q76mpIBg/CreateTweet'
-    const authorization = 'Bearer AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA'
-    const body = {
-        variables: {
-            tweet_text: text
-        },
-        features: {
-            tweetypie_unmention_optimization_enabled: true,
-            responsive_web_edit_tweet_api_enabled: true,
-            graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
-            view_counts_everywhere_api_enabled: true,
-            longform_notetweets_consumption_enabled: true,
-            responsive_web_twitter_article_tweet_consumption_enabled: false,
-            tweet_awards_web_tipping_enabled: false,
-            longform_notetweets_rich_text_read_enabled: true,
-            longform_notetweets_inline_media_enabled: true,
-            responsive_web_graphql_exclude_directive_enabled: true,
-            verified_phone_label_enabled: false,
-            freedom_of_speech_not_reach_fetch_enabled: true,
-            standardized_nudges_misinfo: true,
-            tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
-            responsive_web_media_download_video_enabled: false,
-            responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
-            responsive_web_graphql_timeline_navigation_enabled: true,
-            responsive_web_enhance_cards_enabled: false
+import { match } from "https://deno.land/x/pattern_match@1.0.0-beta.3/mod.ts";
+import { CreateTweetRequest } from "./types.ts";
+
+export const tweet = async (
+  text: string,
+  authToken: string,
+  ct0: string,
+  mediaIds?: string[],
+) => {
+  const url =
+    "https://twitter.com/i/api/graphql/tTsjMKyhajZvK4q76mpIBg/CreateTweet";
+  const authorization =
+    "Bearer AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA";
+  const body: CreateTweetRequest = {
+    variables: {
+      tweet_text: text,
+    },
+    features: {
+      tweetypie_unmention_optimization_enabled: true,
+      responsive_web_edit_tweet_api_enabled: true,
+      graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
+      view_counts_everywhere_api_enabled: true,
+      longform_notetweets_consumption_enabled: true,
+      responsive_web_twitter_article_tweet_consumption_enabled: false,
+      tweet_awards_web_tipping_enabled: false,
+      longform_notetweets_rich_text_read_enabled: true,
+      longform_notetweets_inline_media_enabled: true,
+      responsive_web_graphql_exclude_directive_enabled: true,
+      verified_phone_label_enabled: false,
+      freedom_of_speech_not_reach_fetch_enabled: true,
+      standardized_nudges_misinfo: true,
+      tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled:
+        true,
+      responsive_web_media_download_video_enabled: false,
+      responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+      responsive_web_graphql_timeline_navigation_enabled: true,
+      responsive_web_enhance_cards_enabled: false,
+    },
+  };
+  if (mediaIds) {
+    body.variables.media = {
+      "media_entities": mediaIds.map((mediaId) => (
+        {
+          "media_id": mediaId,
+          "tagged_users": [],
         }
+      )),
+      "possibly_sensitive": false,
+    };
+  }
+
+  return await fetch(url, {
+    headers: {
+      "content-type": "application/json",
+      "authorization": authorization,
+      "x-csrf-token": ct0,
+      "cookie": `auth_token=${authToken}; ct0=${ct0};`,
+    },
+    body: JSON.stringify(body),
+    method: "POST",
+  });
+};
+
+export const uploadMediaFromURL = async (
+  mediaURL: string,
+  type: string,
+  authToken: string,
+  ct0: string,
+) => {
+  const authorization =
+    "Bearer AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA";
+
+  const res = await fetch(mediaURL);
+  const blob = await res.blob();
+  const mediaType = match(type, {
+    "image/jpeg": () => "tweet_image",
+    "image/png": () => "tweet_image",
+    "image/gif": () => "tweet_gif",
+    "video/mp4": () => "tweet_video",
+
+    [match._]: () => {
+      throw new Error(`Unsupported media type: ${type}`);
     }
-    return await fetch(url, {
-        headers: {
-            'content-type': 'application/json',
-            'authorization': authorization,
-            'x-csrf-token': ct0,
-            'cookie': `auth_token=${authToken}; ct0=${ct0};`
-        },
-        body: JSON.stringify(body),
-        method: 'POST',
-    })
-}
+  })
+
+  const initURL =
+    `https://upload.twitter.com/i/media/upload.json?command=INIT&total_bytes=${blob.size}&media_type=${
+      encodeURIComponent(type)
+    }&media_category=${mediaType}`;
+
+  // メディアアップロードを宣言する
+  const uploadInitRes = await fetch(initURL, {
+    method: "POST",
+    headers: {
+      "authorization": authorization,
+      "x-csrf-token": ct0,
+      "cookie": `auth_token=${authToken}; ct0=${ct0};`,
+      "Origin": "https://twitter.com",
+    },
+  });
+  if (!uploadInitRes.ok) {
+    console.log(uploadInitRes);
+    throw new Error("Failed to initialize upload");
+  }
+  const mediaInfo: { media_id_string: string } = await uploadInitRes.json();
+
+  // 5MBごとに分割してアップロード
+  const chunkSize = 5 * 1024 * 1024;
+  const chunks = [];
+  for (let i = 0; i < blob.size; i += chunkSize) {
+    chunks.push(blob.slice(i, i + chunkSize));
+  }
+
+  await Promise.all(chunks.map(async (chunk, index) => {
+    const appendURL =
+      `https://upload.twitter.com/i/media/upload.json?command=APPEND&media_id=${mediaInfo.media_id_string}&segment_index=${index}`;
+    const body = new FormData();
+    body.append("media", chunk);
+    const uploadAppendRes = await fetch(appendURL, {
+      method: "POST",
+      body,
+      headers: {
+        "authorization": authorization,
+        "x-csrf-token": ct0,
+        "cookie": `auth_token=${authToken}; ct0=${ct0};`,
+        "Origin": "https://twitter.com",
+      },
+    });
+    if (!uploadAppendRes.ok) {
+      console.log(uploadAppendRes);
+      throw new Error(`Failed to upload chunk ${index}`);
+    }
+  }));
+
+  // アップロード完了
+  const finalizeURL =
+    `https://upload.twitter.com/i/media/upload.json?command=FINALIZE&media_id=${mediaInfo.media_id_string}`;
+  const uploadFinalizeRes = await fetch(finalizeURL, {
+    method: "POST",
+    headers: {
+      "authorization": authorization,
+      "x-csrf-token": ct0,
+      "cookie": `auth_token=${authToken}; ct0=${ct0};`,
+      "Origin": "https://twitter.com",
+    },
+  });
+  if (!uploadFinalizeRes.ok) {
+    throw new Error("Failed to finalize upload");
+  }
+
+  return mediaInfo.media_id_string;
+};

--- a/types.ts
+++ b/types.ts
@@ -1,18 +1,51 @@
 export type Payload = {
-    body: {
-        note: Note
-    }
-}
+  body: {
+    note: Note;
+  };
+};
 
 type Note = {
-    text: string | null
-    cw: string | null
-    visibility: 'public' | 'home' | 'followers' | 'specified'
-    localOnly: boolean
-    files: File[]
-}
+  text: string | null;
+  cw: string | null;
+  visibility: "public" | "home" | "followers" | "specified";
+  localOnly: boolean;
+  files: File[];
+};
 
 type File = {
-    url: string
-    type: string
-}
+  url: string;
+  type: string;
+};
+
+export type CreateTweetRequest = {
+  variables: {
+    tweet_text: string;
+    media?: {
+      media_entities: {
+        media_id: string;
+      }[];
+      possibly_sensitive: boolean;
+    };
+  };
+  features: {
+    tweetypie_unmention_optimization_enabled: boolean;
+    responsive_web_edit_tweet_api_enabled: boolean;
+    graphql_is_translatable_rweb_tweet_is_translatable_enabled: boolean;
+    view_counts_everywhere_api_enabled: boolean;
+    longform_notetweets_consumption_enabled: boolean;
+    responsive_web_twitter_article_tweet_consumption_enabled: boolean;
+    tweet_awards_web_tipping_enabled: boolean;
+    longform_notetweets_rich_text_read_enabled: boolean;
+    longform_notetweets_inline_media_enabled: boolean;
+    responsive_web_graphql_exclude_directive_enabled: boolean;
+    verified_phone_label_enabled: boolean;
+    freedom_of_speech_not_reach_fetch_enabled: boolean;
+    standardized_nudges_misinfo: boolean;
+    tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled:
+      boolean;
+    responsive_web_media_download_video_enabled: boolean;
+    responsive_web_graphql_skip_user_profile_image_extensions_enabled: boolean;
+    responsive_web_graphql_timeline_navigation_enabled: boolean;
+    responsive_web_enhance_cards_enabled: boolean;
+  };
+};


### PR DESCRIPTION
- 添付ファイルの内MIME Typeが`image/jpeg`, `image/png`, `image/gif`, `image/webp`, `video/mp4`のファイルをTwitterにもアップロードする
- 1つのTweetに対して動画は1つ、画像は4つまでしか添付できないので、それ以上のファイルは従来どおりMisskeyへのリンクを本文に追加する